### PR TITLE
Added import-scm options

### DIFF
--- a/CoverityBuild/CoverityBuild.ps1
+++ b/CoverityBuild/CoverityBuild.ps1
@@ -57,8 +57,6 @@ try {
 	& $PSScriptRoot\EchoArgs.exe --append-log --dir $intermediate $msbuildPath $solution /p:SkipInvalidConfigurations=true /p:Configuration=$configuration /p:Platform=$platform $covbuildargs
 	& $covBuildCmd --append-log --dir $intermediate $msbuildPath $solution /p:SkipInvalidConfigurations=true /p:Configuration=$configuration /p:Platform=$platform $covbuildargs.Split(" ")
 
-	Exit-OnError
-
 	if ($enableScmImport)
 	{
 		Write-Output "#################### COV-IMPORT-SCM ######################"

--- a/CoverityBuild/CoverityBuild.ps1
+++ b/CoverityBuild/CoverityBuild.ps1
@@ -65,7 +65,7 @@ try {
 		& $PSScriptRoot\EchoArgs.exe --dir $intermediate --scm $scmType $covscmargs
 		& $covImportScmCmd --dir $intermediate --scm $scmType $covscmargs.Split(" ")
 
-		Exit-OnError
+		#Exit-OnError
 	}
 
 	Write-Output "#################### COV-ANALYZE ####################"
@@ -87,7 +87,7 @@ try {
 	& $PSScriptRoot\EchoArgs.exe --dir $intermediate $extraAnalyzerArgs --strip-path "$cwd" $covanalyzeargs
 	& $covAnalyzeCmd --dir $intermediate $extraAnalyzerArgs --strip-path "$cwd" $covanalyzeargs.Split(" ")
 
-	Exit-OnError
+	#Exit-OnError
 
 	Write-Output "#################### COV-DEFECTS ####################"
 
@@ -96,7 +96,7 @@ try {
 	& $PSScriptRoot\EchoArgs.exe --dir $intermediate --stream "$stream" --auth-key-file "$authKeyFile" --host $hostname --port $port $covcommitargs
 	& $covCommitCmd --dir $intermediate --stream "$stream" --auth-key-file "$authKeyFile" --host $hostname --port $port $covcommitargs.Split(" ")
 
-	Exit-OnError
+	#Exit-OnError
 }
 finally
 {

--- a/CoverityBuild/CoverityBuild.ps1
+++ b/CoverityBuild/CoverityBuild.ps1
@@ -29,6 +29,7 @@ try {
 	[boolean]$webSecurityCheckers = Get-VstsInput -Name webSecurityCheckers -AsBool
 	[boolean]$webSecurityPreviewCheckers = Get-VstsInput -Name webSecurityPreviewCheckers -AsBool
 	[boolean]$enableCallgraphMetrics = $TRUE
+	[boolean]$enableTestMetrics = $TRUE
 
 	# Source functions
 	. "$PSScriptRoot/Functions.ps1"
@@ -78,9 +79,10 @@ try {
 	$webSecurityArgs = If ($webSecurityCheckers) { "--webapp-security" } Else { $null }
 	$webPreviewSecurityArgs = If ($webSecurityPreviewCheckers) { "--webapp-security-preview" } Else { $null }
 	$callgraphMetrics = If ($enableCallgraphMetrics) {"--enable-callgraph-metrics" } Else { $null }
+	$testMetrics = If ($enableTestMetrics) {"--enable-test-metrics" } Else { $null }
 
 	# Putting it all together to avoid an insanely long argument list further down
-	$userOptions =  @($enableCheckersArgs, $disableCheckersArgs, $allCheckersArgs, $webSecurityArgs, $webPreviewSecurityArgs)
+	$userOptions =  @($enableCheckersArgs, $disableCheckersArgs, $allCheckersArgs, $webSecurityArgs, $webPreviewSecurityArgs, $callgraphMetrics, $testMetrics)
 	$userOptions = $userOptions | Where { -not [string]::IsNullOrWhiteSpace($_) }
 	$allArgs = "--dir $intermediate $userOptions --strip-path '$cwd' $covanalyzeargs"
 

--- a/CoverityBuild/CoverityBuild.ps1
+++ b/CoverityBuild/CoverityBuild.ps1
@@ -16,9 +16,12 @@ try {
 	[string]$authKeyFile = Get-VstsInput -Name authKeyFile
 	[string]$intermediate = Get-VstsInput -Name idir
 	[string]$stream = Get-VstsInput -Name stream
+	[boolean]$enableScmImport = Get-VstsInput -Name enableScmImport -AsBool
+	[string]$scmType = Get-VstsInput -Name scmType
 	[string]$covbuildargs = Get-VstsInput -Name covbuildargs
 	[string]$covanalyzeargs = Get-VstsInput -Name covanalyzeargs
 	[string]$covcommitargs = Get-VstsInput -Name covcommitargs
+	[string]$covscmargs = Get-VstsInput -Name covscmargs
 	[string]$cwd = Get-VstsInput -Name cwd -Require
 	[string]$customCheckers = Get-VstsInput -Name customCheckers
 	[string]$disabledCheckers = Get-VstsInput -Name disabledCheckers
@@ -56,13 +59,16 @@ try {
 
 	Exit-OnError
 
-	Write-Output "#################### COV-IMPORT-SCM ######################"
-	$covImportScmCmd = "$covBinPath/cov-import-scm.exe"
-	Write-Verbose "Executing Cov-ImportScm Command: $covImportScmCmd"
-	& $PSScriptRoot\EchoArgs.exe --dir $intermediate --scm git
-	& $covImportScmCmd --dir $intermediate --scm git
+	if ($enableScmImport)
+	{
+		Write-Output "#################### COV-IMPORT-SCM ######################"
+		$covImportScmCmd = "$covBinPath/cov-import-scm.exe"
+		Write-Verbose "Executing Cov-ImportScm Command: $covImportScmCmd"
+		& $PSScriptRoot\EchoArgs.exe --dir $intermediate --scm $scmType $covscmargs
+		& $covImportScmCmd --dir $intermediate --scm $scmType $covscmargs.Split(" ")
 
-	Exit-OnError
+		Exit-OnError
+	}
 
 	Write-Output "#################### COV-ANALYZE ####################"
 

--- a/CoverityBuild/CoverityBuild.ps1
+++ b/CoverityBuild/CoverityBuild.ps1
@@ -28,6 +28,7 @@ try {
 	[boolean]$allCheckers = Get-VstsInput -Name allCheckers -AsBool
 	[boolean]$webSecurityCheckers = Get-VstsInput -Name webSecurityCheckers -AsBool
 	[boolean]$webSecurityPreviewCheckers = Get-VstsInput -Name webSecurityPreviewCheckers -AsBool
+	[boolean]$enableCallgraphMetrics = $TRUE
 
 	# Source functions
 	. "$PSScriptRoot/Functions.ps1"
@@ -76,6 +77,7 @@ try {
 	$allCheckersArgs = If ($allCheckers) { "--all" } Else { $null }
 	$webSecurityArgs = If ($webSecurityCheckers) { "--webapp-security" } Else { $null }
 	$webPreviewSecurityArgs = If ($webSecurityPreviewCheckers) { "--webapp-security-preview" } Else { $null }
+	$callgraphMetrics = If ($enableCallgraphMetrics) {"--enable-callgraph-metrics" } Else { $null }
 
 	# Putting it all together to avoid an insanely long argument list further down
 	$userOptions =  @($enableCheckersArgs, $disableCheckersArgs, $allCheckersArgs, $webSecurityArgs, $webPreviewSecurityArgs)

--- a/CoverityBuild/Functions.ps1
+++ b/CoverityBuild/Functions.ps1
@@ -52,7 +52,7 @@ function Exit-OnError()
 {
 	if ($? -ne 0)
 	{
-		Write-Host "Exiting because previous command failed."
+		Write-Error "Exiting because previous command failed."
 		exit $?
 	}
 }

--- a/CoverityBuild/task.json
+++ b/CoverityBuild/task.json
@@ -47,8 +47,8 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "1",
-    "Patch": "4"
+    "Minor": "2",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Coverity Build and Analysis",

--- a/CoverityBuild/task.json
+++ b/CoverityBuild/task.json
@@ -34,6 +34,11 @@
       "isExpanded": false
     },
     {
+      "name": "scmSettings",
+      "displayName": "Source Control Settings",
+      "isExpanded": false
+    },
+    {
       "name": "advanced",
       "displayName": "Advanced",
       "isExpanded": false
@@ -43,7 +48,7 @@
   "version": {
     "Major": "1",
     "Minor": "1",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Coverity Build and Analysis",
@@ -174,6 +179,24 @@
       "groupName": "analysisSettings"
     },
     {
+      "name": "enableScmImport",
+      "type": "boolean",
+      "label": "Enable SCM Annotation import for ownership assignment",
+      "defaultvalue": true,
+      "required": false,
+      "helpMarkDown": "If enabled an attempt wll be made to import source control annotation when assigning defect owner using cov-import-scm",
+      "groupName": "scmSettings"
+    },
+    {
+      "name": "scmType",
+      "type": "string",
+      "label": "Source Control Management System",
+      "defaultValue": "git",
+      "required": false,
+      "helpMarkDown": "Source Control Management System that cov-import-scm should use, typically git, svn, tfs etc. Refer to the coverity manual for possible options.",
+      "groupName": "scmSettings"
+    },
+    {
       "name": "idir",
       "type": "filePath",
       "label": "Intermediate Directory",
@@ -184,7 +207,7 @@
     },
     {
       "name": "covbuildargs",
-      "type": "cov-build arguments",
+      "type": "string",
       "label": "Arguments for cov-build",
       "defaultValue": "",
       "required": false,
@@ -193,7 +216,7 @@
     },
     {
       "name": "covanalyzeargs",
-      "type": "cov-analyze arguments",
+      "type": "string",
       "label": "Arguments for cov-analyze",
       "defaultValue": "",
       "required": false,
@@ -202,11 +225,20 @@
     },
     {
       "name": "covcommitargs",
-      "type": "cov-commit-defects arguments",
+      "type": "string",
       "label": "Arguments for cov-commit-defects",
       "defaultValue": "",
       "required": false,
       "helpMarkDOwn": "Additional arguments to pass to the cov-commit-defects command",
+      "groupName": "advanced"
+    },
+    {
+      "name": "covscmargs",
+      "type": "string",
+      "label": "Arguments for cov-import-scm",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDOwn": "Additional arguments to pass to the cov-import-scm command, the default arguments contains the scm type and the intermediate dir.",
       "groupName": "advanced"
     }
   ],

--- a/CoverityBuild/task.json
+++ b/CoverityBuild/task.json
@@ -48,7 +48,7 @@
   "version": {
     "Major": "1",
     "Minor": "1",
-    "Patch": "1"
+    "Patch": "4"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Coverity Build and Analysis",


### PR DESCRIPTION
Added options to configure import-scm and removed "exit on error" code because Coverity cli tools aren't really working that well with .NET code (obj/ files being analyzed).
